### PR TITLE
Fix sp crash and force enable on mirror_city

### DIFF
--- a/PeePee.flipside/mod.json
+++ b/PeePee.flipside/mod.json
@@ -3,6 +3,12 @@
 	"Description" : "Flipside Gamemode",
 	"Version": "0.1.0",
 	"LoadPriority": 5,
+	"ConVars": [
+		{
+			"Name": "Flipside",
+			"DefaultValue": "0"
+		}
+	],
 	"Scripts": [
 		{
 			"Path": "flipside.gnut",

--- a/PeePee.flipside/mod/scripts/vscripts/flipside.gnut
+++ b/PeePee.flipside/mod/scripts/vscripts/flipside.gnut
@@ -75,7 +75,7 @@ int function GetUpDownOffset()
     return 0
 }
 bool function FlipsideEnabled(){
-    return GetCurrentPlaylistVarInt("Flipside", 0) == 1
+    return GetCurrentPlaylistVarInt("Flipside", 0) == 1 || GetConVarInt("Flipside") == 1
 }
 void function OnStart(){
     #if SERVER

--- a/PeePee.flipside/mod/scripts/vscripts/weapons/mp_ability_shifter_super.nut
+++ b/PeePee.flipside/mod/scripts/vscripts/weapons/mp_ability_shifter_super.nut
@@ -7,7 +7,7 @@ const SHIFTER_SUPER_DURATION = 999999
 //<2745.16, 1774, 25.8693>  <2563.61, 2097.9, 268.031>
 var function OnWeaponPrimaryAttack_shifter_super( entity weapon, WeaponPrimaryAttackParams attackParams )
 {
-    if(GetCurrentPlaylistVarInt("Flipside", 0) == 1){
+    if(FlipsideEnabled()){
         float warmupTime = SHIFTER_SUPER_WARMUP_TIME
         if ( weapon.HasMod( "short_shift" ) )
         {
@@ -27,7 +27,9 @@ var function OnWeaponPrimaryAttack_shifter_super( entity weapon, WeaponPrimaryAt
             #if BATTLECHATTER_ENABLED && SERVER
                 TryPlayWeaponBattleChatterLine( weaponOwner, weapon )
             #endif
+            #if MP
             TeleportPlayer(weapon, weaponOwner)
+            #endif
             return weapon.GetWeaponSettingInt( eWeaponVar.ammo_min_to_fire )
         }
         #endif
@@ -90,6 +92,9 @@ bool function PlayerPosInSolid( entity player, vector targetPos )
 
     return false
 
+}
+bool function FlipsideEnabled(){
+    return GetCurrentPlaylistVarInt("Flipside", 0) == 1 || GetConVarInt("Flipside") == 1
 }
 
 //script GetPlayerArray()[0].SetOrigin(< -205 + (-205.0 - GetPlayerArray()[0].GetOrigin().x), 127 + (127 - GetPlayerArray()[0].GetOrigin().y) ,500>)

--- a/PeePee.flipside/mod/scripts/vscripts/weapons/mp_titanability_phase_dash.nut
+++ b/PeePee.flipside/mod/scripts/vscripts/weapons/mp_titanability_phase_dash.nut
@@ -21,7 +21,7 @@ var function OnWeaponPrimaryAttack_titanability_phase_dash( entity weapon, Weapo
 			if ( player.IsPlayer() )
 			{
 				PlayerUsedOffhand( player, weapon )
-				if(GetCurrentPlaylistVarInt("Flipside", 0) == 0){
+				if(FlipsideEnabled()){
 				#if SERVER
 					EmitSoundOnEntityExceptToPlayer( player, player, "Stryder.Dash" )
 					thread PhaseDash( weapon, player )
@@ -43,7 +43,7 @@ var function OnWeaponPrimaryAttack_titanability_phase_dash( entity weapon, Weapo
 				#endif
 				}
 				else{
-					#if SERVER
+					#if SERVER && MP
 					TeleportPlayer(weapon, player)
 					#endif
 					return weapon.GetWeaponSettingInt( eWeaponVar.ammo_per_shot )
@@ -117,4 +117,7 @@ bool function PlayerPosInSolid( entity player, vector targetPos )
 
     return false
 
+}
+bool function FlipsideEnabled(){
+    return GetCurrentPlaylistVarInt("Flipside", 0) == 1 || GetConVarInt("Flipside") == 1
 }


### PR DESCRIPTION
I added a SetConVarInt to mirror_city so people would have to have flipside enabled and also fixed sp crashes.